### PR TITLE
Define  sub dir to be used for cf push

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,38 @@ This is a work in progress.
 ## Options
 
 You can now pass the ``appdir`` parameter to define what directory should be used for your CF APP. This can be usefull if you have multiple cf apps in one repository
+
+If you're not sure about the used directoy that is created in the docker container you can make use of the ``debug`` parameter to list all directories
+
+### Example
+
+Create you github action file and only listen to the events in a given folder
+
+``yml
+
+name: Deploy to Cloud Foundry
+on:
+  push:
+    paths:
+    - 'BTP/cf_python/**'
+    
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name : CF PUSH
+        uses: rangulvers/cf-push@main
+        with:
+          appdir:   './BTP/cf_python/testapp'
+          api:      ${{ secrets.CF_API }}
+          org:      ${{ secrets.CF_ORG }}
+          space:    ${{ secrets.CF_SPACE }}
+          username: ${{ secrets.CF_USERNAME }}
+          password: ${{ secrets.CF_PASSWORD }}
+          manifest: manifest.yml
+          validate: true          
+``
+
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ cf push Github Action
 =====================
 
 This is a work in progress.
+
+
+## Options
+
+You can now pass the ``appdir`` parameter to define what directory should be used for your CF APP. This can be usefull if you have multiple cf apps in one repository

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a frindly fork of [jhunt/cf-push](https://github.com/jhunt/cf-push)
+
 cf push Github Action
 =====================
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you're not sure about the used directoy that is created in the docker contain
 
 Create you github action file and only listen to the events in a given folder
 
-``yml
+```yml
 
 name: Deploy to Cloud Foundry
 on:
@@ -41,6 +41,6 @@ jobs:
           password: ${{ secrets.CF_PASSWORD }}
           manifest: manifest.yml
           validate: true          
-``
+```
 
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: true
   workdir:
     description: Set this parameter if you want to switch the working dir to push an app
-    required: false
+    required: true
   validate:
     description: Whether or not to validate the CF API's TLS certificate
     required: false

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,9 @@ inputs:
   manifest:
     description: The path to your CF application manifest
     required: true
-#   workdir:
-#     description: Set this parameter if you want to switch the working dir to push an app
-#     required: true
+  appdir:
+    description: Set this parameter if you want to switch the working dir to push an app
+    required: true
   api:
     description: The Cloud Foundry API endpoint
     required: true
@@ -22,10 +22,10 @@ inputs:
   space:
     description: The name of the Cloud Foundry space in which to deploy
     required: true
-  workdir:
+  validate:
     description: Whether or not to validate the CF API's TLS certificate
     required: false
-#     default: true
+    default: true
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Whether or not to validate the CF API's TLS certificate
     required: false
     default: true
+  debug:
+    description: Debug your deploy dir
+    required: false
+    default: false
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Whether or not to validate the CF API's TLS certificate
     required: false
     default: true
+  workingdir:
+    description: Set this parameter if you want to switch the working dir to push an app
+    required: false
+
 
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,14 @@ inputs:
   space:
     description: The name of the Cloud Foundry space in which to deploy
     required: true
+  workdir:
+    description: Set this parameter if you want to switch the working dir to push an app
+    required: false
   validate:
     description: Whether or not to validate the CF API's TLS certificate
     required: false
     default: true
-  workingdir:
-    description: Set this parameter if you want to switch the working dir to push an app
-    required: false
+
 
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,9 @@ inputs:
   manifest:
     description: The path to your CF application manifest
     required: true
-  workdir:
-    description: Set this parameter if you want to switch the working dir to push an app
-    required: true
+#   workdir:
+#     description: Set this parameter if you want to switch the working dir to push an app
+#     required: true
   api:
     description: The Cloud Foundry API endpoint
     required: true
@@ -22,10 +22,10 @@ inputs:
   space:
     description: The name of the Cloud Foundry space in which to deploy
     required: true
-  validate:
+  workdir:
     description: Whether or not to validate the CF API's TLS certificate
     required: false
-    default: true
+#     default: true
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   manifest:
     description: The path to your CF application manifest
     required: true
+  workdir:
+    description: Set this parameter if you want to switch the working dir to push an app
+    required: true
   api:
     description: The Cloud Foundry API endpoint
     required: true
@@ -18,9 +21,6 @@ inputs:
     required: true
   space:
     description: The name of the Cloud Foundry space in which to deploy
-    required: true
-  workdir:
-    description: Set this parameter if you want to switch the working dir to push an app
     required: true
   validate:
     description: Whether or not to validate the CF API's TLS certificate

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,15 @@ if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
   cf_opts="--skip-ssl-validation"
 fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
-echo ${INPUT_APPKDIR}
+# echo ${INPUT_APPKDIR}
 
-if [ -z ${INPUT_APPKDIR+x} ]; then 
+if [ -z ${INPUT_APPDIR+x} ]; then 
   echo "WORKDIR is not set. Staying in Root Dir"; else 
-    echo ${INPUT_APPKDIR}
-    cd ${INPUT_APPKDIR}
+    echo ${INPUT_APPDIR}
+    cd ${INPUT_APPDIR}
 fi
 # change dir to push only this app
-cd {INPUT_WORKINGDIR}
+# cd {INPUT_APPDIR}
 
 cf api ${INPUT_API} ${cf_opts}
 CF_USERNAME=${INPUT_USERNAME} CF_PASSWORD=${INPUT_PASSWORD} cf auth

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/sh -l
-set -eu
+# set -eu
 cf_opts= 
 if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
   cf_opts="--skip-ssl-validation"
 fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
 # echo ${INPUT_APPKDIR}
-
+ls
 if [ -z ${INPUT_APPDIR+x} ]; then 
   echo "WORKDIR is not set. Staying in Root Dir"; else 
     echo ${INPUT_APPDIR}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,16 +4,17 @@ cf_opts=
 if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
   cf_opts="--skip-ssl-validation"
 fi
-#/home/runner/work/cf_python_test_app/cf_python_test_app
-# echo ${INPUT_APPKDIR}
-ls -R
+
+if [ "x${INPUT_DEBUG}" = "xtrue" ]; then
+  echo "Your selected APPDIR : ${INPUT_APPDIR}"
+  ls -R
+fi
+
 if [ -z ${INPUT_APPDIR+x} ]; then 
   echo "WORKDIR is not set. Staying in Root Dir"; else 
     echo ${INPUT_APPDIR}
     cd ${INPUT_APPDIR}
 fi
-# change dir to push only this app
-# cd {INPUT_APPDIR}
 
 cf api ${INPUT_API} ${cf_opts}
 CF_USERNAME=${INPUT_USERNAME} CF_PASSWORD=${INPUT_PASSWORD} cf auth

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ fi
 
 if [ -z ${INPUT_WORKINGDIR+x} ]; then 
   echo "WORKINGDIR is not set. Staying in Root Dir"; else 
+    echo {INPUT_WORKINGDIR}
     cd {INPUT_WORKINGDIR}
 fi
 #change dir to push only this app

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -l
-# set -eu
+set -eu
 cf_opts= 
 if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
   cf_opts="--skip-ssl-validation"
@@ -7,15 +7,15 @@ fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
 echo ${INPUT_APPKDIR}
 
-# if [ -z ${INPUT_APPKDIR+x} ]; then 
-#   echo "WORKDIR is not set. Staying in Root Dir"; else 
-#     echo ${INPUT_APPKDIR}
-#     cd ${INPUT_APPKDIR}
-# fi
-#change dir to push only this app
-#cd {INPUT_WORKINGDIR}
+if [ -z ${INPUT_APPKDIR+x} ]; then 
+  echo "WORKDIR is not set. Staying in Root Dir"; else 
+    echo ${INPUT_APPKDIR}
+    cd ${INPUT_APPKDIR}
+fi
+# change dir to push only this app
+cd {INPUT_WORKINGDIR}
 
-# cf api ${INPUT_API} ${cf_opts}
-# CF_USERNAME=${INPUT_USERNAME} CF_PASSWORD=${INPUT_PASSWORD} cf auth
-# cf target -o ${INPUT_ORG} -s ${INPUT_SPACE}
-# cf push -f ${INPUT_MANIFEST}
+cf api ${INPUT_API} ${cf_opts}
+CF_USERNAME=${INPUT_USERNAME} CF_PASSWORD=${INPUT_PASSWORD} cf auth
+cf target -o ${INPUT_ORG} -s ${INPUT_SPACE}
+cf push -f ${INPUT_MANIFEST}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/sh -l
 set -eu
-# cf_opts= 
-# if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
-#   cf_opts="--skip-ssl-validation"
-# fi
+cf_opts= 
+if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
+  cf_opts="--skip-ssl-validation"
+fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
 echo ${INPUT_WORKDIR}
 
@@ -15,7 +15,7 @@ fi
 #change dir to push only this app
 #cd {INPUT_WORKINGDIR}
 
-cf api ${INPUT_API} ${cf_opts}
-CF_USERNAME=${INPUT_USERNAME} CF_PASSWORD=${INPUT_PASSWORD} cf auth
-cf target -o ${INPUT_ORG} -s ${INPUT_SPACE}
-cf push -f ${INPUT_MANIFEST}
+# cf api ${INPUT_API} ${cf_opts}
+# CF_USERNAME=${INPUT_USERNAME} CF_PASSWORD=${INPUT_PASSWORD} cf auth
+# cf target -o ${INPUT_ORG} -s ${INPUT_SPACE}
+# cf push -f ${INPUT_MANIFEST}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,15 @@ cf_opts=
 if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
   cf_opts="--skip-ssl-validation"
 fi
+#/home/runner/work/cf_python_test_app/cf_python_test_app
+
+if [ -z ${INPUT_WORKINGDIR+x} ]; then 
+  echo "WORKINGDIR is not set. Staying in Root Dir"; else 
+    cd {INPUT_WORKINGDIR}
+fi
+#change dir to push only this app
+#cd {INPUT_WORKINGDIR}
+
 cf api ${INPUT_API} ${cf_opts}
 CF_USERNAME=${INPUT_USERNAME} CF_PASSWORD=${INPUT_PASSWORD} cf auth
 cf target -o ${INPUT_ORG} -s ${INPUT_SPACE}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,10 @@ if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
 fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
 
-if [ -z ${INPUT_WORKINGDIR+x} ]; then 
-  echo "WORKINGDIR is not set. Staying in Root Dir"; else 
-    echo {INPUT_WORKINGDIR}
-    cd {INPUT_WORKINGDIR}
+if [ -z ${INPUT_WORKDIR+x} ]; then 
+  echo "WORKDIR is not set. Staying in Root Dir"; else 
+    echo {INPUT_WORKDIR}
+    cd {INPUT_WORKDIR}
 fi
 #change dir to push only this app
 #cd {INPUT_WORKINGDIR}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
 fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
 # echo ${INPUT_APPKDIR}
-ls
+ls -R
 if [ -z ${INPUT_APPDIR+x} ]; then 
   echo "WORKDIR is not set. Staying in Root Dir"; else 
     echo ${INPUT_APPDIR}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -l
-set -eu
+# set -eu
 cf_opts= 
 if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
   cf_opts="--skip-ssl-validation"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,13 @@ if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
   cf_opts="--skip-ssl-validation"
 fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
-echo ${INPUT_WORKDIR}
+echo ${INPUT_APPKDIR}
 
-if [ -z ${INPUT_WORKDIR+x} ]; then 
-  echo "WORKDIR is not set. Staying in Root Dir"; else 
-    echo ${INPUT_WORKDIR}
-    cd ${INPUT_WORKDIR}
-fi
+# if [ -z ${INPUT_APPKDIR+x} ]; then 
+#   echo "WORKDIR is not set. Staying in Root Dir"; else 
+#     echo ${INPUT_APPKDIR}
+#     cd ${INPUT_APPKDIR}
+# fi
 #change dir to push only this app
 #cd {INPUT_WORKINGDIR}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
 set -eu
-cf_opts=
-if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
-  cf_opts="--skip-ssl-validation"
-fi
+# cf_opts= 
+# if [ "x${INPUT_VALIDATE}" = "xfalse" ]; then
+#   cf_opts="--skip-ssl-validation"
+# fi
 #/home/runner/work/cf_python_test_app/cf_python_test_app
+echo ${INPUT_WORKDIR}
 
 if [ -z ${INPUT_WORKDIR+x} ]; then 
   echo "WORKDIR is not set. Staying in Root Dir"; else 
-    echo {INPUT_WORKDIR}
-    cd {INPUT_WORKDIR}
+    echo ${INPUT_WORKDIR}
+    cd ${INPUT_WORKDIR}
 fi
 #change dir to push only this app
 #cd {INPUT_WORKINGDIR}


### PR DESCRIPTION
After your feedback I added the option to define a directory to be used. 

Use Case : if you have a collection of cf apps in one repo it is now possible to define the sub folder to be used. This way only the specific app will be pushed and no extra repos are needed. Useful for teaching purposes 

In addition a debug parameter can be set to list all subdirs. This can help to correctly setup the github action script